### PR TITLE
tc: Use correct mask for u32 matcher

### DIFF
--- a/tc.c
+++ b/tc.c
@@ -60,9 +60,9 @@ void tc_allow_mac(const uint8_t mac[], uint8_t prio)
     snprintf(mac32, 9, "%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3]);
     snprintf(mac16, 5, "%02x%02x", mac[4], mac[5]);
     snprintf(cmd, 2048, "tc filter add dev %s protocol all parent ffff: prio %d "
-             "basic match \"u32(u32 0x%s 0x%s at -8)\" "
-             "and \"u32(u16 0x%s 0x%s at -4)\" flowid :1 action pass",
-             g_interface, prio, mac32, mac32, mac16, mac16);
+             "basic match \"u32(u32 0x%s 0xffffffff at -8)\" "
+             "and \"u32(u16 0x%s 0xffff at -4)\" flowid :1 action pass",
+             g_interface, prio, mac32, mac16);
     log_trace("CMD: %s\n", cmd);
     system(cmd);
 }
@@ -75,9 +75,9 @@ void tc_disallow_mac(const uint8_t mac[], uint8_t prio)
     snprintf(mac32, 9, "%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3]);
     snprintf(mac16, 5, "%02x%02x", mac[4], mac[5]);
     snprintf(cmd, 2048, "tc filter delete dev %s protocol all parent ffff: prio %d "
-             "basic match \"u32(u32 0x%s 0x%s at -8)\" "
-             "and \"u32(u16 0x%s 0x%s at -4)\" flowid :1 action pass",
-             g_interface, prio, mac32, mac32, mac16, mac16);
+             "basic match \"u32(u32 0x%s 0xffffffff at -8)\" "
+             "and \"u32(u16 0x%s 0xffff at -4)\" flowid :1 action pass",
+             g_interface, prio, mac32, mac16);
     log_trace("CMD: %s\n", cmd);
     system(cmd);
 }


### PR DESCRIPTION
Previously, the mac address was inserted into both the VALUE
and MASK arguemnt of the u32 matcher. This is of course incorrect,
because then only 1-bits of the mac address are actually matched by
the kernel.

Therefore the correct mask is used instead. The second u32 matcher
only uses a 16 bit mask, because the other 16 bits of the 32-bit field contain
the ethertype.

Fixes: #1

Signed-off-by: Fabian Bläse <fabian@blaese.de>